### PR TITLE
docs: clarify ghcrawl skill CLI guidance

### DIFF
--- a/skills/ghcrawl/SKILL.md
+++ b/skills/ghcrawl/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ghcrawl
-description: "Use a local ghcrawl install to refresh GitHub repo data, inspect duplicate clusters, and dump issue/PR summaries from the local SQLite dataset. Use when a user wants to triage related issues or PRs, inspect semantic clusters, or refresh one repo through ghcrawl's staged pipeline."
+description: "Use the local ghcrawl CLI to inspect duplicate clusters and issue/PR summaries from the existing ghcrawl dataset, and refresh one repo only when the user explicitly asks. Use when a user wants to triage related issues or PRs, inspect semantic clusters, or run ghcrawl's staged refresh pipeline."
 allowed-tools: Bash(ghcrawl:*), Bash(pnpm:*), Read(*)
 ---
 
@@ -8,12 +8,16 @@ allowed-tools: Bash(ghcrawl:*), Bash(pnpm:*), Read(*)
 
 Use `ghcrawl` as the machine-facing interface for local GitHub duplicate-cluster analysis.
 
+Never read the ghcrawl SQLite database directly with `sqlite3` or any other database client. If the supported CLI cannot return the needed information, report that CLI problem to the user instead of bypassing the interface.
+
 Do not scrape the TUI. Prefer JSON CLI output.
 
 The skill has two modes:
 
-- Default mode: assume there are no valid API keys and stay read-only.
+- Default mode: assume API credentials are absent, unavailable, or irrelevant and stay read-only on existing local data.
 - API-enabled mode: only after `ghcrawl doctor --json` proves GitHub and OpenAI auth are configured and healthy.
+
+In default mode, do not treat missing credentials as a problem unless the user explicitly asked for an API-backed operation or a supported read-only CLI command failed and `doctor` shows local setup is broken.
 
 Even in API-enabled mode, never run `sync`, `embed`, `cluster`, or `refresh` unless the user explicitly asks for that work. Those commands can take a long time, consume paid API usage, and trigger rate limiting if used too often.
 
@@ -34,6 +38,8 @@ If `ghcrawl` is not on `PATH`, use:
 ```bash
 npx ghcrawl cli ...
 ```
+
+Do not start by running `ghcrawl --help` or `<subcommand> --help`. The documented command surface in this skill and [references/protocol.md](references/protocol.md) is the default source of truth. Only use help output when the user explicitly asks about CLI syntax or you are actively maintaining ghcrawl itself.
 
 ## Core workflow
 
@@ -56,6 +62,8 @@ ghcrawl neighbors owner/repo --number 42 --limit 10
 ```
 
 These operate on the existing local SQLite dataset.
+
+Treat that stored dataset as the default source of truth for read-only analysis. Do not probe credentials, inspect env vars, or explain missing auth unless an API-backed task was requested or the supported CLI path is failing.
 
 By default:
 
@@ -103,7 +111,19 @@ Interpret the result like this:
 - If GitHub/OpenAI auth is missing or unhealthy, stay in read-only mode.
 - If GitHub/OpenAI auth is healthy, API-backed operations are available, but still require explicit user direction.
 
-### 3. Refresh local data only when explicitly requested
+If `doctor` is unhealthy but the user asked only for read-only inspection, say that API-backed refresh is unavailable and continue with read-only CLI commands when possible.
+
+### 3. If the CLI is unavailable or misbehaving
+
+Use one supported fallback path before giving up:
+
+```bash
+pnpm --filter ghcrawl cli ...
+```
+
+If a documented `ghcrawl` command still fails, hangs, or returns unusable output through the supported CLI path, stop and report that to the user. Do not inspect tables, schema, or rows with `sqlite3`, `pragma`, or ad hoc SQL.
+
+### 4. Refresh local data only when explicitly requested
 
 Only if the user explicitly asks to refresh or rebuild data, and doctor says auth is healthy, use:
 
@@ -126,7 +146,7 @@ ghcrawl refresh owner/repo --no-cluster
 
 Do not decide on your own to run `cluster` just because it is local-only. It is still long-running and should be treated as an explicit user-directed operation.
 
-### 4. List clusters
+### 5. List clusters
 
 Use:
 
@@ -140,7 +160,7 @@ This returns:
 - freshness state
 - cluster summaries
 
-### 5. Inspect one cluster
+### 6. Inspect one cluster
 
 Use:
 
@@ -155,7 +175,7 @@ This returns:
 - a body snippet
 - stored summary fields when present
 
-### 6. Optional deeper inspection
+### 7. Optional deeper inspection
 
 Use search or neighbors as needed:
 

--- a/skills/ghcrawl/agents/openai.yaml
+++ b/skills/ghcrawl/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "ghcrawl"
-  short_description: "Refresh and inspect local GitHub issue/PR clusters"
-  default_prompt: "Use $ghcrawl to refresh a repo locally, list the latest clusters, and inspect one cluster in detail."
+  short_description: "Inspect local GitHub issue/PR clusters through the ghcrawl CLI"
+  default_prompt: "Use $ghcrawl to inspect a repo through the ghcrawl CLI, list the latest clusters, and inspect one cluster in detail. Refresh only if the user explicitly asks."

--- a/skills/ghcrawl/references/protocol.md
+++ b/skills/ghcrawl/references/protocol.md
@@ -2,13 +2,17 @@
 
 Use the JSON CLI surface. Do not parse the TUI.
 
+Do not query the ghcrawl SQLite database directly with `sqlite3`, `pragma`, or ad hoc SQL. If the supported CLI cannot answer a read-only question, report the CLI problem to the user instead of bypassing the interface.
+
+Do not start with `ghcrawl --help` or `<subcommand> --help`. Use the command surface documented here unless the user explicitly asked about CLI syntax or you are maintaining ghcrawl itself.
+
 ## Commands
 
 ### `ghcrawl doctor --json`
 
 Health and auth smoke check.
 
-Use this first. Treat the result as a gate:
+Use this only when needed. Treat the result as a gate:
 
 - If GitHub/OpenAI auth is missing or unhealthy, stay read-only.
 - If GitHub/OpenAI auth is healthy, API-backed commands are available, but still require explicit user direction.
@@ -17,6 +21,8 @@ Do not call this automatically on every skill invocation. Use it when:
 
 - the user explicitly asked for API-backed work
 - or a read-only request failed and local setup/auth may be the reason
+
+If the user asked only for read-only analysis, missing auth is not itself a blocker. Work from the existing local dataset through the CLI.
 
 ### `ghcrawl threads owner/repo --numbers <n,n,...>`
 
@@ -179,6 +185,8 @@ pnpm --filter ghcrawl cli cluster-detail owner/repo --id 123 --member-limit 20 -
 pnpm --filter ghcrawl cli close-thread owner/repo --number 42
 pnpm --filter ghcrawl cli close-cluster owner/repo --id 123
 ```
+
+If the supported CLI path still fails, hangs, or returns unusable output, stop and tell the user there is a ghcrawl CLI problem. Do not fall back to direct SQLite inspection.
 
 ## Suggested analysis flow
 


### PR DESCRIPTION
## Summary
- make the ghcrawl skill default to CLI-based read-only inspection without treating missing credentials as a problem
- explicitly forbid sqlite CLI and ad hoc SQL fallback when ghcrawl commands fail
- discourage leading with --help and update the skill metadata prompt to emphasize inspection over refresh

## Testing
- not run (docs-only change)