### PR TITLE
fix: grant PR comment workflow pull-request scope

### DIFF
--- a/.github/workflows/cluster-perf-comment.yml
+++ b/.github/workflows/cluster-perf-comment.yml
@@ -19,6 +19,7 @@ permissions:
   actions: read
   contents: read
   issues: write
+  pull-requests: write
 
 jobs:
   update-pr-comment:


### PR DESCRIPTION
## Summary
- add `pull-requests: write` to the `Cluster Perf PR Comment` workflow permissions
- keep the existing `issues: write` scope for issue-comment creation/update
- unblock sticky cluster perf comments on rebased PRs like #7

## Why
The comment workflow was firing, downloading the perf artifact correctly, and then failing with `403 Resource not accessible by integration` when posting the PR comment. GitHub's error path advertised `issues=write; pull_requests=write`, so this patch grants the missing PR write scope.
