### PR TITLE
feat: add configurable project manager skill

### DIFF
--- a/.agents/project-manager.config.json
+++ b/.agents/project-manager.config.json
@@ -1,0 +1,9 @@
+{
+  "repo": "pwrdrvr/ghcrawl",
+  "projectOwner": "pwrdrvr",
+  "projectNumber": 9,
+  "projectUrl": "https://github.com/orgs/pwrdrvr/projects/9",
+  "trackerPath": ".local/work-items.yaml",
+  "issueDraftDir": ".local/issue-drafts",
+  "localIdPrefix": "ghc-"
+}

--- a/.agents/skills/project-manager/SKILL.md
+++ b/.agents/skills/project-manager/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: project-manager
+description: "Manage GitHub issues and the GitHub Project board for the current repository, while keeping the local tracker in sync. Use when the user wants to capture freeform requirements as issues, flesh out issue descriptions from repo or upstream research, triage Priority/Size/Workflow/Status, add issues or PRs to the repo's configured project board, or reconcile GitHub state with `.local/work-items.yaml`."
+---
+
+# Project Manager
+
+Use this skill for repo-local project management.
+
+## Automation Preference
+
+- Prefer Node scripts for repo-local automation.
+- If a script needs dependencies, add them as repo `devDependencies` and invoke them through `pnpm` or `node`.
+- Avoid Python for repo-local skill automation unless a Python-native library is clearly worth the extra runtime dependency.
+
+## Canonical Locations
+
+- Treat GitHub Issues and PRs as the public source of truth.
+- Treat `.local/work-items.yaml` as a derived repo-local cross-reference map that can be regenerated from the project board.
+- Put temporary issue writeups only in `.local/issue-drafts/`.
+- Do not create parallel scratch directories or alternate tracker files for the same purpose.
+- Read repo-specific values from `.agents/project-manager.config.json` before taking action.
+
+Expected config shape:
+
+```json
+{
+  "repo": "owner/repo",
+  "projectOwner": "owner",
+  "projectNumber": 7,
+  "projectUrl": "https://github.com/orgs/owner/projects/7",
+  "trackerPath": ".local/work-items.yaml",
+  "issueDraftDir": ".local/issue-drafts",
+  "localIdPrefix": "item-"
+}
+```
+
+Refresh the derived tracker with:
+
+```bash
+pnpm project:sync
+```
+
+## Workflow
+
+1. Explore before filing.
+
+- Read local code, tests, docs, and upstream references before creating or expanding an issue.
+- Prefer issue bodies with concrete findings, source pointers, and proposed scope over vague placeholders.
+
+2. Draft locally when the issue is non-trivial.
+
+- Write or refresh the issue body in `.local/issue-drafts/<nn>-<slug>.md`.
+- Reuse that file for edits; do not fork the same issue into multiple local scratch notes.
+
+3. Create or update the GitHub issue.
+
+- Use `gh issue create`, `gh issue edit`, and `gh issue comment`.
+- Keep titles short and imperative, usually starting with `Plugin:`.
+
+4. Add the issue or PR to the configured project board.
+
+- Read the configured project number and owner from `.agents/project-manager.config.json`.
+- Use `gh project item-add <project-number> --owner <project-owner> --url <issue-or-pr-url>`.
+- For issues, set `Status`, `Priority`, `Size`, and `Workflow`.
+- For PRs, usually set `Status` and `Workflow`; `Priority` and `Size` are issue-planning fields unless there is a specific reason to set them on the PR item.
+
+5. Sync `.local/work-items.yaml`.
+
+- Treat the tracker as derived state, not a hand-edited source of truth.
+- Regenerate it with `pnpm project:sync` after issue/project changes.
+- Prefer pushing durable notes into GitHub issues or `.local/issue-drafts/`; the tracker should stay compact.
+
+6. Reconcile if anything drifted.
+
+- Use `gh issue list`, `gh project item-list`, and `gh project field-list` to confirm GitHub matches the local tracker.
+
+## Field Conventions
+
+- `Status`: `Inbox`, `Ready`, `In Progress`, `In Review`, `Done`
+- `Workflow`: `Plan`, `Review`, `Threads`, `Worktrees`, `Branches`
+
+Triage heuristic for this repo:
+
+- `P0`: quick wins that shrink the board fast, plus high-visibility completeness or pizazz work
+- `P1`: larger user-visible completeness work
+- `P2`: infrastructure, refactors, planning spikes, and corner-case cleanup unless they are very quick
+
+Size heuristic:
+
+- `XS` or `S`: obvious quick wins
+- `M`: bounded feature or bug fix with a few moving parts
+- `L`: visible feature touching multiple flows
+- `XL`: large architectural or cross-cutting work
+
+## Command Pattern
+
+Start by discovering current project field ids instead of assuming they never change:
+
+```bash
+gh repo view --json nameWithOwner,url
+gh project view <project-number> --owner <project-owner> --format json
+gh project field-list <project-number> --owner <project-owner> --format json
+```
+
+Typical flow:
+
+```bash
+gh issue create --repo <owner/repo> --title "<title>" --body-file .local/issue-drafts/<file>.md
+gh project item-add <project-number> --owner <project-owner> --url <issue-or-pr-url> --format json
+gh project item-edit --project-id <project-id> --id <item-id> --field-id <field-id> --single-select-option-id <option-id>
+gh project item-list <project-number> --owner <project-owner> --format json
+```
+
+Refresh the local tracker:
+
+```bash
+pnpm project:sync
+```
+
+## Gotchas
+
+- Verify the repo slug before issue commands. Treat `.agents/project-manager.config.json` as canonical when it is present.
+- `gh project item-edit` needs opaque ids for the project, item, field, and single-select option. Always discover them with `gh project view ...` and `gh project field-list ...` instead of assuming cached ids still match.
+- GitHub Projects custom views are not well-supported by `gh` or GraphQL mutations. Reading views works, but creating/editing/copying views is still better done in the web UI or browser automation. `gh project copy` does not carry over custom views.
+- `.local/work-items.yaml` is currently issue-only. Add PRs to the project board, but do not expect `pnpm project:sync` to mirror PR items into the local tracker.
+- `.local/issue-drafts/<nn>-<slug>.md` filenames are local scratch ids, not GitHub issue numbers. Keep them stable enough to reuse, but do not try to force them to match the eventual GitHub issue number.
+
+## Tracker Shape
+
+Each `.local/work-items.yaml` item should keep:
+
+- `local_id`
+- `title`
+- `repo`
+- `source_note`
+- `github.issue_number`
+- `github.issue_url`
+- `github.project_number`
+- `github.project_url`
+- `github.project_item_id`
+- `state.issue_state`
+- `state.project_status`
+- `state.workflow`
+- `state.priority`
+- `state.size`
+- optional branch / PR fields
+- concise `notes`
+
+Keep notes factual and short. Store raw findings and writeups in the issue draft file or GitHub issue, not as sprawling tracker prose.

--- a/.agents/skills/project-manager/agents/openai.yaml
+++ b/.agents/skills/project-manager/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Project Manager"
+  short_description: "Manage issues, board, and local tracker"
+  default_prompt: "Use $project-manager to capture requirements into GitHub issues, keep the configured project board in sync, and update the local .local tracker for this repo."

--- a/.agents/skills/project-manager/scripts/sync-work-items.mjs
+++ b/.agents/skills/project-manager/scripts/sync-work-items.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import YAML from "yaml";
+
+const CONFIG_PATH = path.resolve(".agents/project-manager.config.json");
+const DEFAULT_TRACKER_PATH = ".local/work-items.yaml";
+const DEFAULT_LOCAL_ID_PREFIX = "item-";
+
+function runGh(args) {
+  return execFileSync("gh", args, {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function resolveRepoFromGh() {
+  const repo = JSON.parse(runGh(["repo", "view", "--json", "nameWithOwner"]));
+  const nameWithOwner = repo?.nameWithOwner?.trim();
+  if (!nameWithOwner) {
+    throw new Error("Could not determine repo from gh repo view.");
+  }
+  return nameWithOwner;
+}
+
+function loadConfig() {
+  if (!fs.existsSync(CONFIG_PATH)) {
+    throw new Error(`Missing project manager config at ${CONFIG_PATH}`);
+  }
+  const raw = readJson(CONFIG_PATH);
+  const repo =
+    typeof raw.repo === "string" && raw.repo.trim() ? raw.repo.trim() : resolveRepoFromGh();
+  const projectOwner =
+    typeof raw.projectOwner === "string" && raw.projectOwner.trim()
+      ? raw.projectOwner.trim()
+      : repo.split("/")[0];
+  const projectNumber =
+    typeof raw.projectNumber === "number" && Number.isFinite(raw.projectNumber)
+      ? raw.projectNumber
+      : 0;
+  if (projectNumber <= 0) {
+    throw new Error(`Invalid projectNumber in ${CONFIG_PATH}`);
+  }
+  const trackerPath =
+    typeof raw.trackerPath === "string" && raw.trackerPath.trim()
+      ? path.resolve(raw.trackerPath.trim())
+      : path.resolve(DEFAULT_TRACKER_PATH);
+  const projectUrl =
+    typeof raw.projectUrl === "string" && raw.projectUrl.trim()
+      ? raw.projectUrl.trim()
+      : `https://github.com/orgs/${projectOwner}/projects/${projectNumber}`;
+  const localIdPrefix =
+    typeof raw.localIdPrefix === "string" && raw.localIdPrefix.trim()
+      ? raw.localIdPrefix.trim()
+      : DEFAULT_LOCAL_ID_PREFIX;
+  return {
+    repo,
+    projectOwner,
+    projectNumber,
+    projectUrl,
+    trackerPath,
+    localIdPrefix,
+  };
+}
+
+function loadExistingTracker(trackerPath) {
+  if (!fs.existsSync(trackerPath)) {
+    return { version: 1, last_synced_at: null, items: [] };
+  }
+
+  const raw = fs.readFileSync(trackerPath, "utf8");
+  const parsed = YAML.parse(raw) ?? {};
+  return {
+    version: parsed.version ?? 1,
+    last_synced_at: parsed.last_synced_at ?? null,
+    items: Array.isArray(parsed.items) ? parsed.items : [],
+  };
+}
+
+function normalizeNumber(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function nextLocalId(existingItems, localIdPrefix) {
+  let max = 0;
+  for (const item of existingItems) {
+    const match =
+      typeof item?.local_id === "string"
+        ? item.local_id.match(new RegExp(`^${localIdPrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(\\d{4,})$`))
+        : null;
+    if (match) {
+      max = Math.max(max, Number(match[1]));
+    }
+  }
+  return `${localIdPrefix}${String(max + 1).padStart(4, "0")}`;
+}
+
+function mergeExistingItem(existingByIssue, issueNumber, fallbackLocalId, repo) {
+  const current = existingByIssue.get(issueNumber);
+  if (current && typeof current === "object" && current !== null) {
+    return structuredClone(current);
+  }
+  return {
+    local_id: fallbackLocalId,
+    title: "",
+    repo,
+    source_note: "",
+    github: {},
+    state: {},
+    notes: [],
+  };
+}
+
+function main() {
+  const config = loadConfig();
+  const existing = loadExistingTracker(config.trackerPath);
+  const existingByIssue = new Map();
+  for (const item of existing.items) {
+    const issueNumber = normalizeNumber(item?.github?.issue_number);
+    if (issueNumber > 0) {
+      existingByIssue.set(issueNumber, item);
+    }
+  }
+
+  const issueList = JSON.parse(
+    runGh([
+      "issue",
+      "list",
+      "--repo",
+      config.repo,
+      "--state",
+      "all",
+      "--limit",
+      "500",
+      "--json",
+      "number,state,title,url",
+    ]),
+  );
+  const issueByNumber = new Map(issueList.map((issue) => [issue.number, issue]));
+
+  const projectData = JSON.parse(
+    runGh([
+      "project",
+      "item-list",
+      String(config.projectNumber),
+      "--owner",
+      config.projectOwner,
+      "--format",
+      "json",
+    ]),
+  );
+
+  const items = [];
+  for (const item of projectData.items ?? []) {
+    const content = item?.content ?? {};
+    if (content.type !== "Issue") {
+      continue;
+    }
+    if (content.repository !== config.repo) {
+      continue;
+    }
+    const issueNumber = normalizeNumber(content.number);
+    if (issueNumber <= 0) {
+      continue;
+    }
+
+    const issue = issueByNumber.get(issueNumber);
+    const merged = mergeExistingItem(
+      existingByIssue,
+      issueNumber,
+      nextLocalId(existing.items, config.localIdPrefix),
+      config.repo,
+    );
+    merged.title = content.title ?? issue?.title ?? merged.title ?? "";
+    merged.repo = config.repo;
+    merged.source_note = typeof merged.source_note === "string" ? merged.source_note : "";
+    if (typeof merged.raw_example !== "string") {
+      delete merged.raw_example;
+    }
+    merged.github = {
+      ...(merged.github && typeof merged.github === "object" ? merged.github : {}),
+      issue_number: issueNumber,
+      issue_url: content.url ?? issue?.url ?? "",
+      project_number: config.projectNumber,
+      project_url: config.projectUrl,
+      project_item_id: item.id ?? "",
+    };
+    merged.state = {
+      ...(merged.state && typeof merged.state === "object" ? merged.state : {}),
+      issue_state: issue?.state ?? "OPEN",
+      project_status: item.status ?? "",
+      workflow: item.workflow ?? "",
+      priority: item.priority ?? "",
+      size: item.size ?? "",
+      branch: typeof merged.state?.branch === "string" ? merged.state.branch : "",
+      pr_number: normalizeNumber(merged.state?.pr_number),
+      pr_url: typeof merged.state?.pr_url === "string" ? merged.state.pr_url : "",
+    };
+    if (!Array.isArray(merged.notes)) {
+      merged.notes = [];
+    }
+    items.push(merged);
+  }
+
+  items.sort((a, b) => normalizeNumber(a.github?.issue_number) - normalizeNumber(b.github?.issue_number));
+
+  const usedIds = new Set();
+  let counter = 1;
+  for (const item of items) {
+    if (typeof item.local_id !== "string" || usedIds.has(item.local_id)) {
+      while (usedIds.has(`${config.localIdPrefix}${String(counter).padStart(4, "0")}`)) {
+        counter += 1;
+      }
+      item.local_id = `${config.localIdPrefix}${String(counter).padStart(4, "0")}`;
+      counter += 1;
+    }
+    usedIds.add(item.local_id);
+  }
+
+  const output = {
+    version: 1,
+    last_synced_at: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+    items,
+  };
+
+  fs.mkdirSync(path.dirname(config.trackerPath), { recursive: true });
+  fs.writeFileSync(config.trackerPath, YAML.stringify(output, { lineWidth: 0 }), "utf8");
+  process.stdout.write(`Synced ${items.length} items to ${config.trackerPath}\n`);
+}
+
+main();

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,16 @@ Current priorities:
 - operator overview: [README.md](./README.md)
 - maintainer workflow and release notes: [CONTRIBUTING.md](./CONTRIBUTING.md)
 
+## Project Management
+
+Use the repo-local [`project-manager`](./.agents/skills/project-manager/SKILL.md) skill for GitHub issue and project-board work in this repository.
+
+- Repo/project config: `.agents/project-manager.config.json`
+- Project board: <https://github.com/orgs/pwrdrvr/projects/9>
+- Canonical local tracker: `.local/work-items.yaml` (derived; refresh with `pnpm project:sync`)
+- Canonical local issue drafts: `.local/issue-drafts/`
+- Do not create parallel scratch trackers or alternate temp directories for issue workups.
+
 ## Code Areas
 
 - CLI entrypoint: [apps/cli/src/main.ts](./apps/cli/src/main.ts)

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "neighbors": "node ./apps/cli/bin/ghcrawl.js neighbors",
     "tui": "node ./apps/cli/bin/ghcrawl.js tui",
     "serve": "node ./apps/cli/bin/ghcrawl.js serve",
+    "project:sync": "node ./.agents/skills/project-manager/scripts/sync-work-items.mjs",
     "test:cluster-perf": "pnpm --filter @ghcrawl/api-core test:cluster-perf",
     "pack:smoke": "node ./scripts/pack-smoke.mjs",
     "release:apply-version": "node ./scripts/apply-release-version.mjs",
@@ -47,6 +48,7 @@
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^24.3.0",
     "tsx": "^4.20.5",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "yaml": "^2.8.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
+      yaml:
+        specifier: ^2.8.2
+        version: 2.8.2
 
   apps/cli:
     dependencies:
@@ -590,6 +593,11 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  yaml@2.8.2:
+    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
@@ -1083,5 +1091,7 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   wrappy@1.0.2: {}
+
+  yaml@2.8.2: {}
 
   zod@4.3.6: {}


### PR DESCRIPTION
## Summary
- add the repo-local `project-manager` skill and repo config for ghcrawl
- add `pnpm project:sync` to regenerate the derived local tracker from project 9
- document the project-management workflow and board in `AGENTS.md`

## Validation
- `pnpm project:sync`
- did not run `pnpm test`
- did not run `pnpm typecheck`
