### PR TITLE
[codex] refresh cluster perf baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,11 +87,14 @@ Common commands:
 
 - `pnpm typecheck`
 - `pnpm test`
+- `pnpm test:cluster-perf`
 - targeted CLI smoke tests via:
   - `pnpm --filter ghcrawl cli doctor`
   - `pnpm --filter ghcrawl cli sync openclaw/openclaw --limit 1`
 
 If a change affects OpenAI-backed paths, avoid unnecessary live spend unless the user wants a real run.
+
+If a change intentionally improves cluster performance and the CI Cluster Perf job reports a better steady-state result, update [packages/api-core/src/cluster/perf-baseline.json](./packages/api-core/src/cluster/perf-baseline.json) in the same change or immediate follow-up using the reported `fixtureMedianMs` and `projectedOpenclawMs`.
 
 When you create or update a PR, follow through on GitHub Actions with `gh`:
 

--- a/packages/api-core/src/cluster/perf-baseline.json
+++ b/packages/api-core/src/cluster/perf-baseline.json
@@ -21,8 +21,8 @@
     "maxTotalMs": 10000
   },
   "baseline": {
-    "fixtureMedianMs": 535.1,
-    "projectedOpenclawMs": 600000
+    "fixtureMedianMs": 450.6,
+    "projectedOpenclawMs": 505300
   },
   "thresholds": {
     "maxRegressionPercent": 50

--- a/packages/api-core/src/cluster/perf.integration.ts
+++ b/packages/api-core/src/cluster/perf.integration.ts
@@ -53,6 +53,11 @@ type PerfRunResult = {
   maxRegressionPercent: number;
 };
 
+type SuggestedBaseline = {
+  fixtureMedianMs: number;
+  projectedOpenclawMs: number;
+};
+
 const BASELINE_PATH = fileURLToPath(new URL('./perf-baseline.json', import.meta.url));
 
 function loadBaseline(): PerfBaseline {
@@ -89,6 +94,26 @@ function median(values: number[]): number {
     return (sorted[middle - 1] + sorted[middle]) / 2;
   }
   return sorted[middle] ?? 0;
+}
+
+function roundFixtureMedianMs(value: number): number {
+  return Number(value.toFixed(1));
+}
+
+function roundProjectedOpenclawMs(value: number): number {
+  return Math.round(value);
+}
+
+function buildSuggestedBaseline(result: PerfRunResult): SuggestedBaseline | null {
+  const shouldSuggest = result.deltaPercent < 0 || result.baselineMedianMs === result.medianMs;
+  if (!shouldSuggest) {
+    return null;
+  }
+
+  return {
+    fixtureMedianMs: roundFixtureMedianMs(result.medianMs),
+    projectedOpenclawMs: roundProjectedOpenclawMs(result.projectedOpenclawMs),
+  };
 }
 
 function createGitHubStub(): GHCrawlService['github'] {
@@ -348,10 +373,14 @@ async function measureBenchmark(baseline: PerfBaseline): Promise<PerfRunResult> 
 function buildSummary(result: PerfRunResult): string {
   const status = result.deltaPercent > result.maxRegressionPercent ? 'FAIL' : 'PASS';
   const sampleList = result.sampleDurationsMs.map((value) => formatDurationMs(value)).join(', ');
+  const suggestedBaseline = buildSuggestedBaseline(result);
   const bootstrapLine =
     result.baselineMedianMs === result.medianMs
       ? '- Bootstrap mode: using the current fixture median as the provisional baseline'
       : null;
+  const suggestedBaselineLine = suggestedBaseline
+    ? `- Suggested baseline update: ${JSON.stringify(suggestedBaseline)}`
+    : null;
   return [
     '## Cluster Performance',
     '',
@@ -365,6 +394,7 @@ function buildSummary(result: PerfRunResult): string {
     `- Regression threshold: ${formatPercent(result.maxRegressionPercent)}`,
     `- Fixture shape: ${result.threadCount} threads x ${result.sourceKinds.length} source kinds`,
     `- Sample durations: ${sampleList}`,
+    suggestedBaselineLine,
     bootstrapLine,
     '',
   ]
@@ -386,6 +416,7 @@ function writeOutput(result: PerfRunResult, summary: string, bootstrap: boolean)
         status: result.deltaPercent > result.maxRegressionPercent ? 'FAIL' : 'PASS',
         bootstrap,
         summary,
+        suggestedBaseline: buildSuggestedBaseline(result),
         result,
       },
       null,
@@ -402,8 +433,9 @@ async function main(): Promise<void> {
   const shouldFail = !bootstrap && result.deltaPercent > result.maxRegressionPercent;
 
   process.stdout.write(`${summary}\n`);
-  if (bootstrap) {
-    process.stdout.write(`Suggested fixtureMedianMs: ${result.medianMs.toFixed(1)}\n`);
+  const suggestedBaseline = buildSuggestedBaseline(result);
+  if (bootstrap && suggestedBaseline) {
+    process.stdout.write(`Suggested baseline update: ${JSON.stringify(suggestedBaseline)}\n`);
   }
   const summaryPath = process.env.GITHUB_STEP_SUMMARY;
   if (summaryPath) {


### PR DESCRIPTION
## Summary

I refreshed the cluster performance baseline to match the improved CI measurements from the recent clustering speedup.

I also updated the cluster perf benchmark output so CI reports a copyable `Suggested baseline update` object whenever the current run beats the checked-in baseline, and I documented in `AGENTS.md` that intentional perf wins should update the checked-in baseline right away.

## Why

The checked-in baseline was still using the older `535.1 ms` fixture median and `10m 0.0s` projected `openclaw/openclaw` duration even though the current CI run for this benchmark reported `450.6 ms` and `8m 25.3s`.

That left the perf check showing a large negative delta against stale reference numbers instead of comparing future runs against the current expected performance.

## Validation

I ran:

- `pnpm test:cluster-perf`
- `pnpm --filter @ghcrawl/api-contract build && pnpm --filter @ghcrawl/api-core typecheck`
