### PR TITLE
feat: add runtime cost tracking for OpenAI operations

### DIFF
--- a/packages/api-contract/src/contracts.ts
+++ b/packages/api-contract/src/contracts.ts
@@ -201,6 +201,8 @@ export type SyncResultDto = z.infer<typeof syncResultSchema>;
 export const embedResultSchema = z.object({
   runId: z.number().int().positive(),
   embedded: z.number().int().nonnegative(),
+  promptTokens: z.number().int().nonnegative().optional(),
+  estimatedCostUsd: z.number().nonnegative().nullable().optional(),
 });
 export type EmbedResultDto = z.infer<typeof embedResultSchema>;
 

--- a/packages/api-core/src/openai/pricing.test.ts
+++ b/packages/api-core/src/openai/pricing.test.ts
@@ -1,0 +1,54 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { computeCost } from './pricing.js';
+
+test('computeCost returns correct cost for text-embedding-3-large', () => {
+  const cost = computeCost('text-embedding-3-large', { promptTokens: 1_000_000, completionTokens: 0 });
+  assert.notEqual(cost, null);
+  assert.equal(cost!.estimatedCostUsd, 0.13);
+});
+
+test('computeCost returns correct cost for text-embedding-3-small', () => {
+  const cost = computeCost('text-embedding-3-small', { promptTokens: 1_000_000, completionTokens: 0 });
+  assert.notEqual(cost, null);
+  assert.equal(cost!.estimatedCostUsd, 0.02);
+});
+
+test('computeCost handles fractional token counts', () => {
+  const cost = computeCost('text-embedding-3-large', { promptTokens: 285_000, completionTokens: 0 });
+  assert.notEqual(cost, null);
+  assert.ok(Math.abs(cost!.estimatedCostUsd - 0.03705) < 0.00001);
+});
+
+test('computeCost returns correct cost for gpt-5-mini with input and output', () => {
+  const cost = computeCost('gpt-5-mini', { promptTokens: 5_000, completionTokens: 1_000 });
+  assert.notEqual(cost, null);
+  // (5000 * 0.40 / 1M) + (1000 * 1.60 / 1M) = 0.002 + 0.0016 = 0.0036
+  assert.ok(Math.abs(cost!.estimatedCostUsd - 0.0036) < 0.00001);
+});
+
+test('computeCost applies cached input pricing when available', () => {
+  const cost = computeCost('gpt-5-mini', {
+    promptTokens: 5_000,
+    completionTokens: 1_000,
+    cachedPromptTokens: 3_000,
+  });
+  assert.notEqual(cost, null);
+  // non-cached: (5000-3000) * 0.40/1M = 0.0008
+  // cached:     3000 * 0.10/1M         = 0.0003
+  // output:     1000 * 1.60/1M         = 0.0016
+  // total: 0.0027
+  assert.ok(Math.abs(cost!.estimatedCostUsd - 0.0027) < 0.00001);
+});
+
+test('computeCost returns null for unknown model', () => {
+  const cost = computeCost('unknown-model-v9', { promptTokens: 1_000, completionTokens: 0 });
+  assert.equal(cost, null);
+});
+
+test('computeCost returns zero for zero tokens', () => {
+  const cost = computeCost('text-embedding-3-large', { promptTokens: 0, completionTokens: 0 });
+  assert.notEqual(cost, null);
+  assert.equal(cost!.estimatedCostUsd, 0);
+});

--- a/packages/api-core/src/openai/pricing.ts
+++ b/packages/api-core/src/openai/pricing.ts
@@ -1,0 +1,49 @@
+/**
+ * OpenAI pricing catalog for cost estimation.
+ *
+ * Prices as of April 2026. To add a model, insert one entry in CATALOG.
+ * Automated catalog refresh is tracked in issue #23.
+ */
+
+export type TokenUsage = {
+  promptTokens: number;
+  completionTokens: number;
+  cachedPromptTokens?: number;
+};
+
+export type CostResult = {
+  estimatedCostUsd: number;
+};
+
+type ModelPricing = {
+  inputPer1MTokens: number;
+  outputPer1MTokens: number;
+  cachedInputPer1MTokens?: number;
+};
+
+const CATALOG: Record<string, ModelPricing> = {
+  'text-embedding-3-large': { inputPer1MTokens: 0.13, outputPer1MTokens: 0 },
+  'text-embedding-3-small': { inputPer1MTokens: 0.02, outputPer1MTokens: 0 },
+  'gpt-5-mini': { inputPer1MTokens: 0.40, outputPer1MTokens: 1.60, cachedInputPer1MTokens: 0.10 },
+};
+
+/**
+ * Compute estimated cost for a model invocation.
+ * Returns null when the model is not in the catalog.
+ */
+export function computeCost(model: string, usage: TokenUsage): CostResult | null {
+  const pricing = CATALOG[model];
+  if (!pricing) {
+    return null;
+  }
+
+  const cached = usage.cachedPromptTokens ?? 0;
+  const nonCachedInput = usage.promptTokens - cached;
+  const cachedRate = pricing.cachedInputPer1MTokens ?? pricing.inputPer1MTokens;
+
+  const inputCost = (nonCachedInput * pricing.inputPer1MTokens) / 1_000_000;
+  const cachedCost = (cached * cachedRate) / 1_000_000;
+  const outputCost = (usage.completionTokens * pricing.outputPer1MTokens) / 1_000_000;
+
+  return { estimatedCostUsd: inputCost + cachedCost + outputCost };
+}

--- a/packages/api-core/src/openai/provider.ts
+++ b/packages/api-core/src/openai/provider.ts
@@ -18,10 +18,20 @@ export type SummaryUsage = {
   reasoningTokens: number;
 };
 
+export type EmbedUsage = {
+  promptTokens: number;
+  totalTokens: number;
+};
+
+export type EmbedResult = {
+  embeddings: number[][];
+  usage?: EmbedUsage;
+};
+
 export type AiProvider = {
   checkAuth: () => Promise<void>;
   summarizeThread: (params: { model: string; text: string }) => Promise<{ summary: SummaryResult; usage?: SummaryUsage }>;
-  embedTexts: (params: { model: string; texts: string[]; dimensions?: number }) => Promise<number[][]>;
+  embedTexts: (params: { model: string; texts: string[]; dimensions?: number }) => Promise<EmbedResult>;
 };
 
 const summarySchema = z.object({
@@ -116,9 +126,9 @@ export class OpenAiProvider implements AiProvider {
     throw new Error(`OpenAI summarization failed after 3 attempts: ${lastError?.message ?? 'unknown error'}`);
   }
 
-  async embedTexts(params: { model: string; texts: string[]; dimensions?: number }): Promise<number[][]> {
+  async embedTexts(params: { model: string; texts: string[]; dimensions?: number }): Promise<EmbedResult> {
     if (params.texts.length === 0) {
-      return [];
+      return { embeddings: [] };
     }
 
     let lastError: Error | null = null;
@@ -130,7 +140,12 @@ export class OpenAiProvider implements AiProvider {
           dimensions: params.dimensions,
         });
 
-        return response.data.map((item) => item.embedding);
+        return {
+          embeddings: response.data.map((item) => item.embedding),
+          usage: response.usage
+            ? { promptTokens: response.usage.prompt_tokens, totalTokens: response.usage.total_tokens }
+            : undefined,
+        };
       } catch (error) {
         const shouldRetry =
           error instanceof RateLimitError ||

--- a/packages/api-core/src/service.test.ts
+++ b/packages/api-core/src/service.test.ts
@@ -79,7 +79,7 @@ test('doctor reports config path and successful auth smoke checks', async () => 
       summarizeThread: async () => {
         throw new Error('not expected');
       },
-      embedTexts: async () => [],
+      embedTexts: async () => ({ embeddings: [] }),
     },
   });
 
@@ -422,7 +422,7 @@ test('summarizeRepository excludes hydrated comments by default and reports toke
           },
         };
       },
-      embedTexts: async () => [],
+      embedTexts: async () => ({ embeddings: [] }),
     },
   );
 
@@ -484,6 +484,8 @@ test('summarizeRepository excludes hydrated comments by default and reports toke
     assert.equal(result.inputTokens, 123);
     assert.equal(result.outputTokens, 45);
     assert.equal(result.totalTokens, 168);
+    assert.ok(result.estimatedCostUsd !== null, 'should report estimated cost');
+    assert.ok(result.estimatedCostUsd! > 0, 'cost should be positive');
     assert.equal(summaryInputs.length, 1);
     assert.match(summaryInputs[0], /title: Downloader hangs/);
     assert.match(summaryInputs[0], /body: The transfer never finishes\./);
@@ -523,7 +525,7 @@ test('summarizeRepository includes hydrated human comments when includeComments 
           },
         };
       },
-      embedTexts: async () => [],
+      embedTexts: async () => ({ embeddings: [] }),
     },
   );
 
@@ -812,7 +814,11 @@ test('embedRepository batches multi-source embeddings and skips unchanged inputs
       },
       embedTexts: async ({ texts }) => {
         embedCalls.push(texts);
-        return texts.map((text, index) => makeEmbedding(text.length, index));
+        const totalTokens = texts.reduce((sum, t) => sum + t.length, 0);
+        return {
+          embeddings: texts.map((text, index) => makeEmbedding(text.length, index)),
+          usage: { promptTokens: totalTokens, totalTokens },
+        };
       },
     },
   );
@@ -867,6 +873,8 @@ test('embedRepository batches multi-source embeddings and skips unchanged inputs
 
     const first = await service.embedRepository({ owner: 'openclaw', repo: 'openclaw' });
     assert.equal(first.embedded, 1);
+    assert.ok(first.promptTokens !== undefined && first.promptTokens > 0, 'should report prompt tokens');
+    assert.ok(first.estimatedCostUsd !== undefined && first.estimatedCostUsd !== null, 'should report estimated cost');
     assert.equal(embedCalls.length, 1);
     assert.deepEqual(
       service.db
@@ -1062,7 +1070,11 @@ test('embedRepository truncates oversized inputs before submission', async () =>
       },
       embedTexts: async ({ texts }) => {
         embedCalls.push(texts);
-        return texts.map((text, index) => makeEmbedding(text.length, index));
+        const totalTokens = texts.reduce((sum, t) => sum + t.length, 0);
+        return {
+          embeddings: texts.map((text, index) => makeEmbedding(text.length, index)),
+          usage: { promptTokens: totalTokens, totalTokens },
+        };
       },
     },
   });
@@ -1193,7 +1205,11 @@ test('embedRepository isolates a failing oversized item from a mixed batch and r
             );
           }
         }
-        return texts.map((text, index) => makeEmbedding(text.length, index));
+        const totalTokens = texts.reduce((sum, t) => sum + t.length, 0);
+        return {
+          embeddings: texts.map((text, index) => makeEmbedding(text.length, index)),
+          usage: { promptTokens: totalTokens, totalTokens },
+        };
       },
     },
   });
@@ -1319,7 +1335,11 @@ test('embedRepository recovers from wrapped maximum input length errors by shrin
             `OpenAI embeddings failed after 5 attempts: 400 Invalid 'input[${overLimitIndex}]': maximum input length is 8192 tokens.`,
           );
         }
-        return texts.map((text, index) => makeEmbedding(text.length, index));
+        const totalTokens = texts.reduce((sum, t) => sum + t.length, 0);
+        return {
+          embeddings: texts.map((text, index) => makeEmbedding(text.length, index)),
+          usage: { promptTokens: totalTokens, totalTokens },
+        };
       },
     },
   });
@@ -2263,7 +2283,10 @@ test('refreshRepository runs sync, embed, and cluster in order and returns the c
       summarizeThread: async () => {
         throw new Error('not expected');
       },
-      embedTexts: async ({ texts }) => texts.map((_text, index) => makeEmbedding(1, index)),
+      embedTexts: async ({ texts }) => ({
+        embeddings: texts.map((_text, index) => makeEmbedding(1, index)),
+        usage: { promptTokens: texts.length * 10, totalTokens: texts.length * 10 },
+      }),
     },
   );
 

--- a/packages/api-core/src/service.ts
+++ b/packages/api-core/src/service.ts
@@ -65,7 +65,8 @@ import { migrate } from './db/migrate.js';
 import { openDb, type SqliteDatabase } from './db/sqlite.js';
 import { buildCanonicalDocument, isBotLikeAuthor } from './documents/normalize.js';
 import { makeGitHubClient, type GitHubClient } from './github/client.js';
-import { OpenAiProvider, type AiProvider } from './openai/provider.js';
+import { OpenAiProvider, type AiProvider, type EmbedUsage } from './openai/provider.js';
+import { computeCost } from './openai/pricing.js';
 import { cosineSimilarity, dotProduct, normalizeEmbedding, rankNearestNeighbors, rankNearestNeighborsByScore } from './search/exact.js';
 import type { VectorStore } from './vector/store.js';
 import { VectorliteStore } from './vector/vectorlite-store.js';
@@ -1025,7 +1026,7 @@ export class GHCrawlService {
     threadNumber?: number;
     includeComments?: boolean;
     onProgress?: (message: string) => void;
-  }): Promise<{ runId: number; summarized: number; inputTokens: number; outputTokens: number; totalTokens: number }> {
+  }): Promise<{ runId: number; summarized: number; inputTokens: number; outputTokens: number; totalTokens: number; estimatedCostUsd: number | null }> {
     const ai = this.requireAi();
     const repository = this.requireRepository(params.owner, params.repo);
     const runId = this.startRun('summary_runs', repository.id, params.threadNumber ? `thread:${params.threadNumber}` : repository.fullName);
@@ -1160,8 +1161,13 @@ export class GHCrawlService {
         summarized += 1;
       }
 
-      this.finishRun('summary_runs', runId, 'completed', { summarized, inputTokens, outputTokens, totalTokens });
-      return { runId, summarized, inputTokens, outputTokens, totalTokens };
+      const costResult = computeCost(this.config.summaryModel, { promptTokens: inputTokens, completionTokens: outputTokens });
+      const estimatedCostUsd = costResult?.estimatedCostUsd ?? null;
+      params.onProgress?.(
+        `[summarize] done: ${summarized} summarized, ${totalTokens} tokens, estimated cost: $${estimatedCostUsd?.toFixed(4) ?? 'unknown'}`,
+      );
+      this.finishRun('summary_runs', runId, 'completed', { summarized, inputTokens, outputTokens, totalTokens, estimatedCostUsd });
+      return { runId, summarized, inputTokens, outputTokens, totalTokens, estimatedCostUsd };
     } catch (error) {
       this.finishRun('summary_runs', runId, 'failed', null, error);
       throw error;
@@ -1249,6 +1255,7 @@ export class GHCrawlService {
       );
 
       let embedded = 0;
+      let promptTokens = 0;
       const batches = this.chunkEmbeddingTasks(pending, this.config.embedBatchSize, EMBED_MAX_BATCH_TOKENS);
       const mapper = new IterableMapper(
         batches,
@@ -1269,15 +1276,21 @@ export class GHCrawlService {
         params.onProgress?.(
           `[embed] batch ${completedBatches}/${Math.max(batches.length, 1)} size=${batchResult.length} est_tokens=${estimatedTokens} items=${numbers.join(',')}`,
         );
-        for (const { task, embedding } of batchResult) {
+        for (const { task, embedding, usage } of batchResult) {
           this.upsertActiveVector(repository.id, repository.fullName, task.threadId, task.basis, task.contentHash, embedding);
           embedded += 1;
+          if (usage) promptTokens += usage.promptTokens;
         }
       }
 
       this.markRepoVectorsCurrent(repository.id);
-      this.finishRun('embedding_runs', runId, 'completed', { embedded });
-      return embedResultSchema.parse({ runId, embedded });
+      const costResult = computeCost(this.config.embedModel, { promptTokens, completionTokens: 0 });
+      const estimatedCostUsd = costResult?.estimatedCostUsd ?? null;
+      params.onProgress?.(
+        `[embed] done: ${embedded} embedded, ~${promptTokens} tokens, estimated cost: $${estimatedCostUsd?.toFixed(4) ?? 'unknown'}`,
+      );
+      this.finishRun('embedding_runs', runId, 'completed', { embedded, promptTokens, estimatedCostUsd });
+      return embedResultSchema.parse({ runId, embedded, promptTokens, estimatedCostUsd });
     } catch (error) {
       this.finishRun('embedding_runs', runId, 'failed', null, error);
       throw error;
@@ -1727,7 +1740,7 @@ export class GHCrawlService {
 
     if (mode !== 'keyword' && this.ai) {
       if (this.isRepoVectorStateCurrent(repository.id)) {
-        const [queryEmbedding] = await this.ai.embedTexts({
+        const { embeddings: [queryEmbedding] } = await this.ai.embedTexts({
           model: this.config.embedModel,
           texts: [params.query],
           dimensions: ACTIVE_EMBED_DIMENSIONS,
@@ -1744,7 +1757,7 @@ export class GHCrawlService {
           semanticScores.set(neighbor.threadId, Math.max(semanticScores.get(neighbor.threadId) ?? -1, neighbor.score));
         }
       } else if (this.hasLegacyEmbeddings(repository.id)) {
-        const [queryEmbedding] = await this.ai.embedTexts({ model: this.config.embedModel, texts: [params.query] });
+        const { embeddings: [queryEmbedding] } = await this.ai.embedTexts({ model: this.config.embedModel, texts: [params.query] });
         for (const row of this.iterateStoredEmbeddings(repository.id)) {
           const score = cosineSimilarity(queryEmbedding, JSON.parse(row.embedding_json) as number[]);
           if (score < 0.2) continue;
@@ -3593,14 +3606,17 @@ export class GHCrawlService {
     ai: AiProvider,
     batch: ActiveVectorTask[],
     onProgress?: (message: string) => void,
-  ): Promise<Array<{ task: ActiveVectorTask; embedding: number[] }>> {
+  ): Promise<Array<{ task: ActiveVectorTask; embedding: number[]; usage?: EmbedUsage }>> {
     try {
-      const embeddings = await ai.embedTexts({
+      const result = await ai.embedTexts({
         model: this.config.embedModel,
         texts: batch.map((task) => task.text),
         dimensions: ACTIVE_EMBED_DIMENSIONS,
       });
-      return batch.map((task, index) => ({ task, embedding: embeddings[index] }));
+      const perItem = result.usage && batch.length > 0
+        ? { promptTokens: Math.round(result.usage.promptTokens / batch.length), totalTokens: Math.round(result.usage.totalTokens / batch.length) }
+        : undefined;
+      return batch.map((task, index) => ({ task, embedding: result.embeddings[index], usage: perItem }));
     } catch (error) {
       if (!this.isEmbeddingContextError(error) || batch.length === 1) {
         if (batch.length === 1 && this.isEmbeddingContextError(error)) {
@@ -3614,7 +3630,7 @@ export class GHCrawlService {
         `[embed] batch context error; isolating ${batch.length} item(s) to find oversized input(s)`,
       );
 
-      const recovered: Array<{ task: ActiveVectorTask; embedding: number[] }> = [];
+      const recovered: Array<{ task: ActiveVectorTask; embedding: number[]; usage?: EmbedUsage }> = [];
       for (const task of batch) {
         recovered.push(await this.embedSingleTaskWithRecovery(ai, task, onProgress));
       }
@@ -3626,17 +3642,17 @@ export class GHCrawlService {
     ai: AiProvider,
     task: ActiveVectorTask,
     onProgress?: (message: string) => void,
-  ): Promise<{ task: ActiveVectorTask; embedding: number[] }> {
+  ): Promise<{ task: ActiveVectorTask; embedding: number[]; usage?: EmbedUsage }> {
     let current = task;
 
     for (let attempt = 0; attempt < EMBED_CONTEXT_RETRY_ATTEMPTS; attempt += 1) {
       try {
-        const [embedding] = await ai.embedTexts({
+        const result = await ai.embedTexts({
           model: this.config.embedModel,
           texts: [current.text],
           dimensions: ACTIVE_EMBED_DIMENSIONS,
         });
-        return { task: current, embedding };
+        return { task: current, embedding: result.embeddings[0], usage: result.usage };
       } catch (error) {
         const context = this.parseEmbeddingContextError(error);
         if (!context) {


### PR DESCRIPTION
## Summary

Adds cost tracking foundation for OpenAI backed operations, as described in #24.

This PR covers the accounting and reporting layer. Spend limits and interactive confirmation are left for a follow up so this stays review sized.

**What changed:**

- New `pricing.ts` module with a model pricing catalog and `computeCost()` function
- `embedTexts()` now captures and returns token usage from the OpenAI API (was previously discarded)
- `embedRepository()` and `summarizeRepository()` accumulate tokens, compute estimated cost, persist it in `stats_json`, and report it via `onProgress`
- `embedResultSchema` contract extended with optional `promptTokens` and `estimatedCostUsd` fields
- All existing tests updated for the new `EmbedResult` shape, with new cost assertions

**Scope deliberately excluded (follow up):**

- Per run spend limit with interactive confirmation
- Pricing catalog auto refresh (#23)
- TUI cost display

## What it looks like

After an embed or summarize run, the CLI now reports:

```
[embed] done: 142 embedded, ~285000 tokens, estimated cost: $0.0371
[summarize] done: 15 summarized, 6279 tokens, estimated cost: $0.0036
```

Cost data is also persisted in `stats_json` for each run record.

## Test plan

- [x] 7 new unit tests for pricing catalog (known models, unknown model, cached tokens, zero tokens)
- [x] All 71 api-core tests pass with updated mocks
- [x] Cost assertions added to existing embed and summarize tests
- [x] Full suite: 139 pass, 0 fail
- [x] `pnpm typecheck` passes

Closes the accounting portion of #24.